### PR TITLE
fix compile failures on macos m1

### DIFF
--- a/src/start.rs
+++ b/src/start.rs
@@ -41,7 +41,7 @@ fn map_volumes(_ctx: u32, vmcfg: &VmConfig, rootfs: &str) {
 }
 
 #[cfg(target_os = "macos")]
-fn map_volumes(ctx: u32, vmcfg: &VmConfig, _rootfs: &str) {
+fn map_volumes(ctx: u32, vmcfg: &VmConfig, rootfs: &str) {
     let mut volumes = Vec::new();
     for (host_path, guest_path) in vmcfg.mapped_volumes.iter() {
         let full_guest = format!("{}{}", &rootfs, guest_path);
@@ -58,7 +58,7 @@ fn map_volumes(ctx: u32, vmcfg: &VmConfig, _rootfs: &str) {
         vols.push(vol.as_ptr());
     }
     vols.push(std::ptr::null());
-    let ret = bindings::krun_set_mapped_volumes(ctx, vols.as_ptr());
+    let ret = unsafe { bindings::krun_set_mapped_volumes(ctx, vols.as_ptr()) };
     if ret < 0 {
         println!("Error setting VM mapped volumes");
         std::process::exit(-1);


### PR DESCRIPTION
```
error[E0425]: cannot find value `rootfs` in this scope
  --> src/start.rs:47:43
   |
47 |         let full_guest = format!("{}{}", &rootfs, guest_path);
   |                                           ^^^^^^ help: a local variable with a similar name exists: `_rootfs`

error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
  --> src/start.rs:61:15
   |
61 |     let ret = bindings::krun_set_mapped_volumes(ctx, vols.as_ptr());
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
   |
   = note: consult the function's documentation for information on how to avoid undefined behavior

```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>